### PR TITLE
For selectable licenses the restrictions of use are now given as an overview

### DIFF
--- a/metashare/repo2/views.py
+++ b/metashare/repo2/views.py
@@ -184,8 +184,7 @@ def download(request, object_id):
                 LICENCEINFOTYPE_URLS_LICENCE_CHOICES[licence_choice][1] })
     elif len(licences) > 1:
         return render_to_response('repo2/licence_selection.html',
-            { 'form': LicenseSelectionForm([(name, name) for name in licences]),
-              'resource': resource })
+            { 'form': LicenseSelectionForm(licences), 'resource': resource })
     else:
         return render_to_response('repo2/lr_not_downloadable.html',
                                   { 'resource': resource })


### PR DESCRIPTION
This still needs to be prettified with CSS to be really usable. Please merge.
