### PR TITLE
declare the help icon URL in a single place in the base template

### DIFF
--- a/metashare/repository/editor/resource_editor.py
+++ b/metashare/repository/editor/resource_editor.py
@@ -556,7 +556,6 @@ class ResourceModelAdmin(SchemaModelAdmin):
             'save_on_top': self.save_on_top,
             'kb_link': settings.KNOWLEDGE_BASE_URL,
             'comp_name': _('%s') % force_unicode(opts.verbose_name),
-            'help_icon_url': u'%s%s' % (settings.MEDIA_URL, "css/sexybuttons/images/icons/silk/help.png"),
         }
         if extra_context:
             context.update(extra_context)

--- a/metashare/repository/editor/superadmin.py
+++ b/metashare/repository/editor/superadmin.py
@@ -277,7 +277,6 @@ class SchemaModelAdmin(admin.ModelAdmin, RelatedAdminMixin, SchemaModelLookup):
             'app_label': opts.app_label,
             'kb_link': settings.KNOWLEDGE_BASE_URL,
             'comp_name': _('%s') % force_unicode(opts.verbose_name),
-            'help_icon_url': u'%s%s' % (settings.MEDIA_URL, "css/sexybuttons/images/icons/silk/help.png"),
         }
         context.update(extra_context or {})
         return self.render_change_form(request, context, form_url=form_url, add=True)
@@ -409,7 +408,6 @@ class SchemaModelAdmin(admin.ModelAdmin, RelatedAdminMixin, SchemaModelLookup):
             'app_label': opts.app_label,
             'kb_link': settings.KNOWLEDGE_BASE_URL,
             'comp_name': _('%s') % force_unicode(opts.verbose_name),
-            'help_icon_url': u'%s%s' % (settings.MEDIA_URL, "css/sexybuttons/images/icons/silk/help.png"),
         }
         context.update(extra_context or {})
         return self.render_change_form(request, context, change=True, obj=obj)

--- a/metashare/templates/admin/base.html
+++ b/metashare/templates/admin/base.html
@@ -61,7 +61,7 @@
 	{% endfor %}</ul>
         {% endif %}
 
-    <!-- Content -->
+    {# Content #}{% with help_icon_url=MEDIA_URL|add:"css/sexybuttons/images/icons/silk/help.png" %}
     <div id="content" class="{% block coltype %}colM{% endblock %}">
         {% block pretitle %}{% endblock %}
         {% block content_title %}{% if title %}<h1 class="customtitle">{{ title }}</h1><span class="helpLink" kbbase="{{ kb_link }}" kbcomp="{{ comp_name }}"><img class="help_icon" src="{{ help_icon_url }}" kbbase="{{ kb_link }}" kbcomp="{{ comp_name }}"></img></span><div style="clear: both"></div>{% endif %}{% endblock %}
@@ -72,7 +72,7 @@
         {% block sidebar %}{% endblock %}
         <br class="clear" />
     </div>
-    <!-- END Content -->
+    {# END Content #}{% endwith %}
 
     {% block footer %}<div id="footer"></div>{% endblock %}
 </div>


### PR DESCRIPTION
Therewith we can leave the Python code responsible for the business logic only, while the templates can take care of rendering issues
