### PR TITLE
Small issue with python path

### DIFF
--- a/metashare/storage_admin.py
+++ b/metashare/storage_admin.py
@@ -3,7 +3,16 @@ Project: META-SHARE prototype implementation
  Author: Christian Federmann <cfedermann@dfki.de>
 """
 import os
+# Magic python path, based on http://djangosnippets.org/snippets/281/
+
+from os.path import abspath, dirname, join
 import sys
+parentdir = dirname(dirname(abspath(__file__)))
+# Insert our dependencies:
+sys.path.insert(0, join(parentdir, 'lib', 'python2.7', 'site-packages'))
+# Insert our parent directory (the one containing the folder metashare/):
+sys.path.insert(0, parentdir)
+
 from traceback import format_exc
 
 def _import_xml_from_string(x, y):


### PR DESCRIPTION
# Problem

If python, django, etc are installed using `install-dependencies.sh`, the "lib/python2.7/site-packages" directory must be in the python path if we want python to find django and the rest of installed modules.

Currently, manage.py adds the directory to the path.
storage_admin.py does not add the directory "lib/python2.7/site-packages" giving an error when importing django.
# Reproduce the error:

Use install-dependencies, setup metashare, add a resource and try adding a storageobject using storage_admin.py

> python storage_admin.py checksum b189e4a6a2c211e19ae9000e0c4ad2262bb2a705e742487295c2c0965a0b77f8
> Traceback (most recent call last):
>  File "storage_admin.py", line 228, in <module>
>    from metashare.storage.models import StorageObject
>  File "/home/meta1/MetaNode/META-SHARE-v2.1/metashare/storage/models.py", line 8, in <module>
>    from django.core.exceptions import ValidationError
> ImportError: No module named django.core.exceptions
# Solution

With this commit, storage_admin.py adds to the path the required directory.
# Proof that the module is found:

> python storage_admin.py checksum b189e4a6a2c211e19ae9000e0c4ad2262bb2a705e742487295c2c0965a0b77f8
> Checksum: 08b13ea3b9f9df673fb14080b78107b8
