### PR TITLE
don’t overwrite the default “createsuperuser” command

### DIFF
--- a/metashare/sync/management/commands/createsuperuserwithpassword.py
+++ b/metashare/sync/management/commands/createsuperuserwithpassword.py
@@ -8,15 +8,17 @@ class Command(BaseCommand):
             help='Specifies the username for the user.'),
         make_option('--password', dest='password', default=None,
             help='Specifies the password for the user.'),
+        make_option('--email', dest='email', default="",
+            help='Specifies the e-mail for the user. (optional)'),
     )
     def handle(self, *args, **options):
         username = options.get('username', None)
         password = options.get('password', None)
+        email = options.get('email', "")
         if username is None or password is None:
             print "Missing username or password"
             return
 
-        email = "admin@metashare-dummy.org"
         user = User.objects.create_superuser(username, email, password)
         if user is None:
             print "Error in creating user"

--- a/misc/multitest/create_db.sh
+++ b/misc/multitest/create_db.sh
@@ -34,7 +34,7 @@ fi
 
 cd $METASHARE_DIR
 "$PYTHON"  manage.py syncdb --noinput
-"$PYTHON"  manage.py createsuperuser --username=admin --password=secret
+"$PYTHON"  manage.py createsuperuserwithpassword --username=admin --password=secret
 cd $CURRENT_DIR
 
 echo "Database file " $DATABASE_FILE " has been created/updated."


### PR DESCRIPTION
The default command is used at “syncdb” time.
