### PR TITLE
Add javascript files in Media for LangDictWidget. 

### DIFF
--- a/metashare/repository/editor/widgets.py
+++ b/metashare/repository/editor/widgets.py
@@ -176,7 +176,12 @@ class LangDictWidget(DictWidget):
         from the JavaScript of `DictWidget` and CSS specific to this widget.
         """
         # pylint: disable-msg=E1101
-        return Media(js = ('{}js/lang_dict_widget.js'\
+        return Media(js = ('js/jquery-ui.min.js',
+                           '{}js/pycountry.js'\
+                           .format(settings.ADMIN_MEDIA_PREFIX),
+                           '{}js/autocomp.js'\
+                           .format(settings.ADMIN_MEDIA_PREFIX),
+                           '{}js/lang_dict_widget.js'\
                            .format(settings.ADMIN_MEDIA_PREFIX),)) \
             + Media(css={'all': ('{}css/lang_dict_widget.css'.format(
                                         settings.ADMIN_MEDIA_PREFIX),)})


### PR DESCRIPTION
This should fix the bug for the Attribution text / Add button not working.
