### PR TITLE
always cache loaded templates to speed up our single resource view

### DIFF
--- a/metashare/settings.py
+++ b/metashare/settings.py
@@ -115,11 +115,11 @@ ADMIN_MEDIA_PREFIX = '{0}/site_media/admin/'.format(DJANGO_URL)
 
 #ADMIN_MEDIA_ROOT = '{0}/media/admin/'.format(ROOT_PATH)
 
-# List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.load_template_source',
-    'django.template.loaders.app_directories.load_template_source',
-# 'django.template.loaders.eggs.load_template_source',
+    ('django.template.loaders.cached.Loader', (
+        'django.template.loaders.filesystem.Loader',
+        'django.template.loaders.app_directories.Loader',
+    )),
 )
 
 MIDDLEWARE_CLASSES = (


### PR DESCRIPTION
Whenever a template is changed, the server now has to be restarted for the changes to take effect. Our single resource view now loads more than ten times faster than before (at least on my local development machine in `DEBUG` mode).
