### PR TITLE
Accept valid xs:anyURI values that have escaped chars that should not be unquoted.

### DIFF
--- a/metashare/repository/supermodel.py
+++ b/metashare/repository/supermodel.py
@@ -246,7 +246,12 @@ class SchemaModel(models.Model):
             # contain escaped characters; unescape them again for the export
             if field and metashare.repository.models.HTTPURI_VALIDATOR in \
                     field.validators and value:
-                value = urllib.unquote(str(value)).decode('utf8')
+                try:
+                    value = urllib.unquote(str(value)).decode('utf8')
+                except UnicodeError:
+                    # if xs:anyURI value contains escaped characters, that 
+                    # are not to be unquoted, return them as they are
+                    return unicode(value)
 
             return unicode(value)
 


### PR DESCRIPTION
Valid URIs that contain escaped characters (e.g a URI that contains the Norwegian character %f8)
should not be unquoted and thus should be saved as it is.
