### PR TITLE
Avoid 500 server error with IPv6 addresses (GeoIP)

### DIFF
--- a/metashare/stats/geoip.py
+++ b/metashare/stats/geoip.py
@@ -286,6 +286,9 @@ def getcountry_coords(countrycode):
         
 def getcountry_code(ipaddress):
     if (ipaddress != "" and not is_privateIP(ipaddress)):
-        return geoip.country_code_by_addr(ipaddress)
+        try:
+            return geoip.country_code_by_addr(ipaddress)
+        except pygeoip.GeoIPError:
+            return ""
     return ""
     


### PR DESCRIPTION
I get 500 Server errors when searching for resources with a non-empty string.
With `DEBUG=True` I can get the exception: `Invalid database type; expected IPv4 address` which is backtraced to the `getcountry_code` function in the `stats/geoip.py` file.

The proposed try/except patch fixes the issue by returning the default empty string if geoip cannot find the country.

As far as I know, this is used for statistic purposes, so providing the country guessed by the IP it is not crucial for metashare.
