### PR TITLE
Fix static url paths, missed on 1.3-1.4 django update

### DIFF
--- a/metashare/repository/views.py
+++ b/metashare/repository/views.py
@@ -86,59 +86,59 @@ MEMBER_TYPES = type('MemberEnum', (), dict(GOD=100, FULL=3, ASSOCIATE=2, NON=1))
 # is required at a minimum to be able to download the associated resource
 # straight away; otherwise the licence requires a hard-copy signature
 LICENCEINFOTYPE_URLS_LICENCE_CHOICES = {
-  'AGPL': (STATIC_URL + 'licences/GNU_agpl-3.0.htm', MEMBER_TYPES.NON),
-  'LGPL': (STATIC_URL + 'licences/GNU_lgpl-3.0.htm', MEMBER_TYPES.NON),
-  'CC-ZERO': (STATIC_URL + 'licences/CC0v1.0.htm', MEMBER_TYPES.NON),
-  'CC-BY-NC-ND': (STATIC_URL + 'licences/CC-BYNCNDv3.0.htm', MEMBER_TYPES.NON),
-  'CC-BY-NC-SA': (STATIC_URL + 'licences/CC-BYNCSAv3.0.htm', MEMBER_TYPES.NON),
-  'CC-BY-NC': (STATIC_URL + 'licences/CC-BYNCv3.0.htm', MEMBER_TYPES.NON),
-  'CC-BY-ND': (STATIC_URL + 'licences/CC-BYNDv3.0.htm', MEMBER_TYPES.NON),
-  'CC-BY-SA': (STATIC_URL + 'licences/CC-BYSAv3.0.htm', MEMBER_TYPES.NON),
-  'CC-BY': (STATIC_URL + 'licences/CC-BYv3.0.htm', MEMBER_TYPES.NON),
-  'MSCommons-BY': (STATIC_URL + 'licences/META-SHARE_COMMONS_BY_v1.0.htm',
+  'AGPL': (STATIC_URL + 'metashare/licences/GNU_agpl-3.0.htm', MEMBER_TYPES.NON),
+  'LGPL': (STATIC_URL + 'metashare/licences/GNU_lgpl-3.0.htm', MEMBER_TYPES.NON),
+  'CC-ZERO': (STATIC_URL + 'metashare/licences/CC0v1.0.htm', MEMBER_TYPES.NON),
+  'CC-BY-NC-ND': (STATIC_URL + 'metashare/licences/CC-BYNCNDv3.0.htm', MEMBER_TYPES.NON),
+  'CC-BY-NC-SA': (STATIC_URL + 'metashare/licences/CC-BYNCSAv3.0.htm', MEMBER_TYPES.NON),
+  'CC-BY-NC': (STATIC_URL + 'metashare/licences/CC-BYNCv3.0.htm', MEMBER_TYPES.NON),
+  'CC-BY-ND': (STATIC_URL + 'metashare/licences/CC-BYNDv3.0.htm', MEMBER_TYPES.NON),
+  'CC-BY-SA': (STATIC_URL + 'metashare/licences/CC-BYSAv3.0.htm', MEMBER_TYPES.NON),
+  'CC-BY': (STATIC_URL + 'metashare/licences/CC-BYv3.0.htm', MEMBER_TYPES.NON),
+  'MSCommons-BY': (STATIC_URL + 'metashare/licences/META-SHARE_COMMONS_BY_v1.0.htm',
                    MEMBER_TYPES.FULL),
-  'MSCommons-BY-NC': (STATIC_URL + 'licences/META-SHARE_COMMONS_BYNC_v1.0.htm',
+  'MSCommons-BY-NC': (STATIC_URL + 'metashare/licences/META-SHARE_COMMONS_BYNC_v1.0.htm',
                       MEMBER_TYPES.FULL),
-  'MSCommons-BY-NC-ND': (STATIC_URL + 'licences/META-SHARE_COMMONS_BYNCND_' \
+  'MSCommons-BY-NC-ND': (STATIC_URL + 'metashare/licences/META-SHARE_COMMONS_BYNCND_' \
                          'v1.0.htm', MEMBER_TYPES.FULL),
-  'MSCommons-BY-NC-SA': (STATIC_URL + 'licences/META-SHARE_COMMONS_BYNCSA' \
+  'MSCommons-BY-NC-SA': (STATIC_URL + 'metashare/licences/META-SHARE_COMMONS_BYNCSA' \
                          '_v1.0.htm', MEMBER_TYPES.FULL),
-  'MSCommons-BY-ND': (STATIC_URL + 'licences/META-SHARE_COMMONS_BYND_v1.0.htm',
+  'MSCommons-BY-ND': (STATIC_URL + 'metashare/licences/META-SHARE_COMMONS_BYND_v1.0.htm',
                       MEMBER_TYPES.FULL),
-  'MSCommons-BY-SA': (STATIC_URL + 'licences/META-SHARE_COMMONS_BYSA_v1.0.htm',
+  'MSCommons-BY-SA': (STATIC_URL + 'metashare/licences/META-SHARE_COMMONS_BYSA_v1.0.htm',
                       MEMBER_TYPES.FULL),
-  'MS-C-NoReD-FF': (STATIC_URL + 'licences/META-SHARE_Commercial_' \
+  'MS-C-NoReD-FF': (STATIC_URL + 'metashare/licences/META-SHARE_Commercial_' \
         'NoRedistribution_For-a-Fee_v1.0.htm', MEMBER_TYPES.GOD),
-  'MS-C-NoReD': (STATIC_URL + 'licences/META-SHARE_Commercial_' \
+  'MS-C-NoReD': (STATIC_URL + 'metashare/licences/META-SHARE_Commercial_' \
         'NoRedistribution_v1.0.htm', MEMBER_TYPES.GOD),
-  'MS-C-NoReD-ND-FF': (STATIC_URL + 'licences/META-SHARE_Commercial_' \
+  'MS-C-NoReD-ND-FF': (STATIC_URL + 'metashare/licences/META-SHARE_Commercial_' \
         'NoRedistribution_NoDerivatives_For-a-fee-v1.0.htm', MEMBER_TYPES.GOD),
-  'MS-C-NoReD-ND': (STATIC_URL + 'licences/META-SHARE_Commercial_' \
+  'MS-C-NoReD-ND': (STATIC_URL + 'metashare/licences/META-SHARE_Commercial_' \
         'NoRedistribution_NoDerivatives-v1.0.htm', MEMBER_TYPES.GOD),
-  'MS-NC-NoReD-ND-FF': (STATIC_URL + 'licences/META-SHARE_NonCommercial' \
+  'MS-NC-NoReD-ND-FF': (STATIC_URL + 'metashare/licences/META-SHARE_NonCommercial' \
         '_NoRedistribution_NoDerivatives_For-a-fee-v1.0.htm', MEMBER_TYPES.GOD),
-  'MS-NC-NoReD-ND': (STATIC_URL + 'licences/META-SHARE_NonCommercial_' \
+  'MS-NC-NoReD-ND': (STATIC_URL + 'metashare/licences/META-SHARE_NonCommercial_' \
         'NoRedistribution_NoDerivatives-v1.0.htm', MEMBER_TYPES.GOD),
-  'MS-NC-NoReD-FF': (STATIC_URL + 'licences/META-SHARE_NonCommercial' \
+  'MS-NC-NoReD-FF': (STATIC_URL + 'metashare/licences/META-SHARE_NonCommercial' \
         '_NoRedistribution_For-a-Fee-v1.0.htm', MEMBER_TYPES.GOD),
-  'MS-NC-NoReD': (STATIC_URL + 'licences/META-SHARE_NonCommercial_' \
+  'MS-NC-NoReD': (STATIC_URL + 'metashare/licences/META-SHARE_NonCommercial_' \
         'NoRedistribution-v1.0.htm', MEMBER_TYPES.GOD),
-  'ELRA_EVALUATION': (STATIC_URL + 'licences/EVALUATION.htm', MEMBER_TYPES.GOD),
-  'ELRA_VAR': (STATIC_URL + 'licences/VAR-v3_2007.htm', MEMBER_TYPES.GOD),
-  'ELRA_END_USER': (STATIC_URL + 'licences/ENDUSER-v3_2007.htm',
+  'ELRA_EVALUATION': (STATIC_URL + 'metashare/licences/EVALUATION.htm', MEMBER_TYPES.GOD),
+  'ELRA_VAR': (STATIC_URL + 'metashare/licences/VAR-v3_2007.htm', MEMBER_TYPES.GOD),
+  'ELRA_END_USER': (STATIC_URL + 'metashare/licences/ENDUSER-v3_2007.htm',
                     MEMBER_TYPES.GOD),
   'proprietary': ('', MEMBER_TYPES.GOD),
-  'CLARIN_PUB': (STATIC_URL + 'licences/CLARIN_PUB.html', MEMBER_TYPES.GOD),
-  'CLARIN_ACA-NC': (STATIC_URL + 'licences/CLARIN_ACA.html', MEMBER_TYPES.GOD),
-  'CLARIN_ACA': (STATIC_URL + 'licences/CLARIN_ACA.html', MEMBER_TYPES.GOD),
-  'CLARIN_RES': (STATIC_URL + 'licences/CLARIN_RES.html', MEMBER_TYPES.GOD),
-  'Princeton_Wordnet': (STATIC_URL + 'licences/WordNet-3.0.txt',
+  'CLARIN_PUB': (STATIC_URL + 'metashare/licences/CLARIN_PUB.html', MEMBER_TYPES.GOD),
+  'CLARIN_ACA-NC': (STATIC_URL + 'metashare/licences/CLARIN_ACA.html', MEMBER_TYPES.GOD),
+  'CLARIN_ACA': (STATIC_URL + 'metashare/licences/CLARIN_ACA.html', MEMBER_TYPES.GOD),
+  'CLARIN_RES': (STATIC_URL + 'metashare/licences/CLARIN_RES.html', MEMBER_TYPES.GOD),
+  'Princeton_Wordnet': (STATIC_URL + 'metashare/licences/WordNet-3.0.txt',
                         MEMBER_TYPES.NON),
-  'GPL': (STATIC_URL + 'licences/GNU_gpl-3.0.htm', MEMBER_TYPES.NON),
-  'GFDL': (STATIC_URL + 'licences/GNU_fdl-1.3.htm', MEMBER_TYPES.NON),
-  'ApacheLicence_2.0': (STATIC_URL + 'licences/Apache-2.0.htm',
+  'GPL': (STATIC_URL + 'metashare/licences/GNU_gpl-3.0.htm', MEMBER_TYPES.NON),
+  'GFDL': (STATIC_URL + 'metashare/licences/GNU_fdl-1.3.htm', MEMBER_TYPES.NON),
+  'ApacheLicence_2.0': (STATIC_URL + 'metashare/licences/Apache-2.0.htm',
                         MEMBER_TYPES.NON),
-  'BSD': (STATIC_URL + 'licences/BSD_licence.htm', MEMBER_TYPES.NON),
+  'BSD': (STATIC_URL + 'metashare/licences/BSD_licence.htm', MEMBER_TYPES.NON),
   'BSD-style': ('', MEMBER_TYPES.NON),
   'underNegotiation': ('', MEMBER_TYPES.GOD),
   'other': ('', MEMBER_TYPES.GOD)

--- a/metashare/templates/accounts/create_account.html
+++ b/metashare/templates/accounts/create_account.html
@@ -18,7 +18,7 @@
     {% for field in form %}
       {{ field.errors }}
       {% if field.html_name == "accepted_tos" %}
-        {{ field }} <label for="{{ field.auto_id }}">I accept the <a target="_blank" href="{% static "terms_of_service_reg.pdf" %}">META-SHARE Terms of Service for registered users</a>.</label>
+        {{ field }} <label for="{{ field.auto_id }}">I accept the <a target="_blank" href="{% static "metashare/terms_of_service_reg.pdf" %}">META-SHARE Terms of Service for registered users</a>.</label>
       {% else %}
         {{ field.label_tag }} {{ field }}
       {% endif %}

--- a/metashare/templates/accounts/update_default_editor_group.html
+++ b/metashare/templates/accounts/update_default_editor_group.html
@@ -10,7 +10,7 @@
 
 {% block links %}
 {{ form.media }}
-<link rel="stylesheet" type="text/css" href="{% static "css/widgets.css" %}"/>
+<link rel="stylesheet" type="text/css" href="{% static "admin/css/widgets.css" %}"/>
 {% endblock %}
 
 {% block content %}

--- a/metashare/templates/footer.html
+++ b/metashare/templates/footer.html
@@ -4,6 +4,6 @@
 <div id="footer">
   <div class="split"></div>    
   Co-funded by the 7th Framework Programme and the ICT Policy Support Programme of the European Commission through the contracts T4ME (grant agreement no.: 249119), CESAR (grant agreement no.: 271022), METANET4U (grant agreement no.: 270893) and META-NORD (grant agreement no.: 270899).<br/>
-  <a href="http://creativecommons.org/licenses/by-nc-sa/3.0/">Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License</a> &ndash; <a href="{% if request.user.is_authenticated %}{% static "terms_of_service_reg.pdf" %}{% else %}{% static "terms_of_service_non_reg.pdf" %}{% endif %}">Terms of Service</a>
+  <a href="http://creativecommons.org/licenses/by-nc-sa/3.0/">Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License</a> &ndash; <a href="{% if request.user.is_authenticated %}{% static "metashare/terms_of_service_reg.pdf" %}{% else %}{% static "metashare/terms_of_service_non_reg.pdf" %}{% endif %}">Terms of Service</a>
 </div>
 {% endspaceless %}

--- a/metashare/templates/stats/mystats.html
+++ b/metashare/templates/stats/mystats.html
@@ -6,7 +6,7 @@
 {% if not myres %}
     <script>window.location.replace("{% url metashare.views.frontpage %}stats/top/");</script>
 {% endif %}
-<link rel="stylesheet" href="{% static "/css/view_stats.css" %}" type="text/css" media="screen" />
+<link rel="stylesheet" href="{% static "metashare/css/view_stats.css" %}" type="text/css" media="screen" />
 
 <div class='tab-container'>
  <ul class='etabs'>


### PR DESCRIPTION
Hi,

I found 404 errors when seeing license resources after running `python manage.py collectstatic`. I also checked for a couple of extra missed paths from commit https://github.com/metashare/META-SHARE/commit/7aed93d3ed6d8b293b98422ed218a79f46b71dfe

Feel free to merge, if this is still active